### PR TITLE
Fix crash when no settings provided for a delivery method

### DIFF
--- a/lib/actionmailer/balancer/delivery_method.rb
+++ b/lib/actionmailer/balancer/delivery_method.rb
@@ -13,7 +13,7 @@ module ActionMailer
         delivery_method = choose_delivery_method
         message.delivery_method(
           ::ActionMailer::Base.delivery_methods[delivery_method[:method]],
-          delivery_method[:settings]
+          delivery_method[:settings] || {}
         )
         message.deliver!
       end


### PR DESCRIPTION
If using https://github.com/railsware/mailtrap-ruby you don't need to provide any settings for the delivery method normally. When using this gem, I assumed you could just do this:

```ruby
      {
        method: :mailtrap,
        weight: 1
      }
```

But it crashed:

![image](https://github.com/user-attachments/assets/f3d7b67e-a57a-4ede-a589-6264d87a434b)

I think it should provide an empty hash if no settings are provided, [just like Rails does](https://github.com/rails/rails/blob/410ad1c8a18ebf7f544d77d2cb82de2a0e87d23a/actionmailer/lib/action_mailer/delivery_methods.rb#L66). This PR implements that.