### PR TITLE
Release 1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+*.DS_Store
 
 # rspec failure tracking
 .rspec_status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## [1.1.1] - 2024-12-09
+- Fix crash when no settings are provided for a delivery method
+  
+  ```ruby
+  config.action_mailer.balancer_settings = {
+    delivery_methods: [
+      {
+        method: :mailtrap,
+        weight: 1
+      }
+    ]
+  }
+  ``` 
+
+  *Alex Ghiculescu*
+
 ## [1.1.0] - 2024-08-19
 
 - Dropped Ruby 2.7 support

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,9 @@ source 'https://rubygems.org'
 
 gemspec
 
-group :development do
-  gem 'mail'
-  gem 'rake', '~> 13.0'
-  gem 'rspec', '~> 3.0'
-  gem 'rubocop', '~> 1.21'
-  gem 'rubocop-rake', require: false
-  gem 'rubocop-rspec', require: false
-end
+gem 'mail'
+gem 'rake', '~> 13.0'
+gem 'rspec', '~> 3.0'
+gem 'rubocop', '~> 1.21'
+gem 'rubocop-rake'
+gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionmailer-balancer (1.1.0)
+    actionmailer-balancer (1.1.1)
       actionmailer (> 4.0, < 8.0)
 
 GEM

--- a/lib/actionmailer/balancer/version.rb
+++ b/lib/actionmailer/balancer/version.rb
@@ -2,6 +2,6 @@
 
 module ActionMailer
   module Balancer
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end


### PR DESCRIPTION
## Motivation
Release a new version with [the patch](https://github.com/railsware/actionmailer-balancer/pull/28).

## Changes

- Updated Gemfile
- Added Gemfile.lock to gitignore
- Bumped version

## How to test

N/A

## Images and GIFs

N/A