### PR TITLE
Allow Rails 8

### DIFF
--- a/actionmailer-balancer.gemspec
+++ b/actionmailer-balancer.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = 'https://github.com/railsware/actionmailer-balancer/blob/main/CHANGELOG.md'
   spec.metadata['rubygems_mfa_required'] = 'true'
 
-  spec.add_dependency 'actionmailer', '> 4.0', '< 8.0'
+  spec.add_dependency 'actionmailer', '> 4.0'
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
This PR removes the restriction Rails versions below 8. See https://github.com/svenfuchs/rails-i18n/pull/1130 for a discussion around the merits of this. Thanks in advance for your consideration.