### PR TITLE
Release version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.2] - 2024-12-13
+- Allow Rails 8 
+
+  *Alex Ghiculescu*
+
 ## [1.1.1] - 2024-12-09
 - Fix crash when no settings are provided for a delivery method
   
@@ -16,8 +21,8 @@
 
 ## [1.1.0] - 2024-08-19
 
-- Dropped Ruby 2.7 support
-- Updated dependencies
+- Drop Ruby 2.7 support
+- Update dependencies
 
 ## [1.0.0] - 2022-10-07
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionmailer-balancer (1.1.1)
+    actionmailer-balancer (1.1.2)
       actionmailer (> 4.0)
 
 GEM

--- a/lib/actionmailer/balancer/version.rb
+++ b/lib/actionmailer/balancer/version.rb
@@ -2,6 +2,6 @@
 
 module ActionMailer
   module Balancer
-    VERSION = '1.1.1'
+    VERSION = '1.1.2'
   end
 end


### PR DESCRIPTION
## Motivation

Release version 1.1.2 which allows Rails 8 in dependencies.

## Changes

- Allow Rails 8

## How to test

- [ ] Smoke test with Rails 8

## Images and GIFs

N/A
