### PR TITLE
Drop Ruby 3.0 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,10 +9,10 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0.7'
           - '3.1.6'
-          - '3.2.5'
-          - '3.3.4'
+          - '3.2.7'
+          - '3.3.7'
+          - '3.4.2'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-rspec
 
 AllCops:
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
   NewCops: enable
 
 Layout/LineLength:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
+## [1.2.0] - 2025-03-06
+
+- Drop Ruby 3.0 support
+- Update dependencies
+
 ## [1.1.2] - 2024-12-13
+
 - Allow Rails 8 
 
   *Alex Ghiculescu*
 
 ## [1.1.1] - 2024-12-09
+
 - Fix crash when no settings are provided for a delivery method
   
   ```ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    actionmailer-balancer (1.1.2)
+    actionmailer-balancer (1.2.0)
       actionmailer (> 4.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,10 +89,10 @@ GEM
       timeout
     net-smtp (0.5.0)
       net-protocol
-    nokogiri (1.17.2)
+    nokogiri (1.18.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-darwin)
+    nokogiri (1.18.3-x86_64-darwin)
       racc (~> 1.4)
     parallel (1.26.2)
     parser (3.3.4.2)

--- a/actionmailer-balancer.gemspec
+++ b/actionmailer-balancer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
     'Distributes emails across multiple delivery methods in the given proportion.'
   spec.homepage = 'https://github.com/railsware/actionmailer-balancer'
   spec.license = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.1.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/railsware/actionmailer-balancer'

--- a/lib/actionmailer/balancer/version.rb
+++ b/lib/actionmailer/balancer/version.rb
@@ -2,6 +2,6 @@
 
 module ActionMailer
   module Balancer
-    VERSION = '1.1.2'
+    VERSION = '1.2.0'
   end
 end


### PR DESCRIPTION
## Motivation

Ruby 3.0 reached end of life in April 2024.

## Changes

- Drop Ruby 3.0 support
- Bump nokogiri (fixes https://github.com/railsware/actionmailer-balancer/security/dependabot/53)
- Update Ruby testing matrix
- Bump version to 1.2.0

## How to test

- [ ] Not needed.

## Images and GIFs

None.